### PR TITLE
Adding PyPi/PIP to Outbound Whitelist

### DIFF
--- a/whitelist/strict.lst
+++ b/whitelist/strict.lst
@@ -16,3 +16,5 @@ registry.hub.docker.com
 github.com
 api.github.com
 crates.io
+pypi.org
+files.pythonhosted.org


### PR DESCRIPTION
Adding 2 new records to Whitelist Outbound interaction with PyPi/PIP.

PyPi/PIP is commonly used way to install Python Packages. It should NOT be more dangerous that interaction with Github, which is already added to the Whitelist. 

Additionally it is required by Ray on Golem and Jupyter on Golem Projects.