### PR TITLE
Added Golem Registry PROD to strict.lst

### DIFF
--- a/whitelist/strict.lst
+++ b/whitelist/strict.lst
@@ -3,6 +3,7 @@
 13.36.40.74
 geth2.golem.network
 geth.golem.network
+registry.golem.network
 mainnet.infura.io
 polygon-mainnet.infura.io
 polygon-rpc.com


### PR DESCRIPTION
Outbound network to production Golem Registry is not yet whitelisted, so all demands with that url in manifest fails.

I've added a missing entry to the strict list, as `*.dev.golem.network` regexp is not suited for this.